### PR TITLE
Feature/add stripe billing email

### DIFF
--- a/payments/stripe/widgets.py
+++ b/payments/stripe/widgets.py
@@ -20,6 +20,7 @@ class StripeCheckoutWidget(Input):
             'data-key': provider.public_key,
             'data-image': provider.image,
             'data-name': provider.name,
+            'data-email': payment.billing_email,
             'data-description': payment.description or _('Total payment'),
             # Stripe accepts cents
             'data-amount': int(payment.total * 100),


### PR DESCRIPTION
It provides a better UX interacting with the **Stripe's payment form** and improves the **Stripe payment flow** ensuring that an email will be ready to be sended to the payment creator if a receipt is requested (due to the automatic Stripe payment notifications flow, or due to a receipt request using the Dashboard).

Concretely, 
- auto-injects `Payment.billing_email` if exists into the payment form [b8862f8]
- integrates the `receipt_email` property for the `Charge` creation [1dd7fd0]

### Fixed issues
Fix #57
Fix #185

