### PR TITLE
Override the HOST and SSL if `override_domain=True` is passed to `get…

### DIFF
--- a/payments/core.py
+++ b/payments/core.py
@@ -22,9 +22,8 @@ if not PAYMENT_HOST:
 PAYMENT_USES_SSL = getattr(settings, 'PAYMENT_USES_SSL', not settings.DEBUG)
 
 # To override the internal payment callback (not the OK/KO final redirect)
-PAYMENT_HOST_OVERRIDED = getattr(settings, 'PAYMENT_HOST_OVERRIDED', PAYMENT_HOST)
-PAYMENT_USES_SSL_OVERRIDED = getattr(settings, 'PAYMENT_USES_SSL_OVERRIDED', PAYMENT_USES_SSL)
-
+PAYMENT_HOST_OVERRIDDEN = getattr(settings, 'PAYMENT_HOST_OVERRIDDEN', PAYMENT_HOST)
+PAYMENT_USES_SSL_OVERRIDDEN = getattr(settings, 'PAYMENT_USES_SSL_OVERRIDDEN', PAYMENT_USES_SSL)
 
 def get_base_url():
     """

--- a/payments/core.py
+++ b/payments/core.py
@@ -43,9 +43,9 @@ def get_base_url():
         domain = PAYMENT_HOST
     return '%s://%s' % (protocol, domain)
 
-def get_overrided_url():
+def get_overridden_url():
     """
-    Returns the overrided host and protocol
+    Returns the overridden host and protocol
     """
     protocol = 'https' if PAYMENT_USES_SSL_OVERRIDED else 'http'
     domain = PAYMENT_HOST_OVERRIDED

--- a/payments/core.py
+++ b/payments/core.py
@@ -47,8 +47,8 @@ def get_overridden_url():
     """
     Returns the overridden host and protocol
     """
-    protocol = 'https' if PAYMENT_USES_SSL_OVERRIDED else 'http'
-    domain = PAYMENT_HOST_OVERRIDED
+    protocol = 'https' if PAYMENT_USES_SSL_OVERRIDDEN else 'http'
+    domain = PAYMENT_HOST_OVERRIDDEN
     return '%s://%s' % (protocol, domain)
 
 class BasicProvider(object):
@@ -94,12 +94,12 @@ class BasicProvider(object):
         '''
         raise NotImplementedError()
 
-    def get_return_url(self, payment, extra_data=None, override_domain=False):
+    def get_return_url(self, payment, extra_data=None, overridden_domain=False):
         payment_link = payment.get_process_url()
 
-        # Use overrided domain instead of BASE_URL
-        if override_domain:
-            url = get_overrided_url()
+        # Use overridden domain instead of BASE_URL
+        if overridden_domain:
+            url = get_overridden_url()
         else:
             url = get_base_url()
 


### PR DESCRIPTION
Overrides the HOST and SSL if `overridden_domain=True` is passed to `get_return_url`

Also adds new
- `get_overridden_url ` handler
- `PAYMENT_HOST_OVERRIDDEN ` from django.settings (default `PAYMENT_HOST`)
- `PAYMENT_USES_SSL_OVERRIDDEN ` from django.settings (default `PAYMENT_USES_SSL`)

Permits to change the internal callback URL that payment provider will call once a payment is processed